### PR TITLE
Collapse Arrow & Settings

### DIFF
--- a/archive/AdvList.ts
+++ b/archive/AdvList.ts
@@ -1,3 +1,4 @@
+/*
 import { Editor, Notice } from "obsidian";
 import { ADVERSARIES } from "../../../data/index";
 import { filterByTier } from "../../../utils/index";
@@ -124,4 +125,4 @@ function buildCardHTML(
 </section>
 `;
 	return cardHTML.trim().replace(/\s+$/, "");
-}
+}*/

--- a/src/docs/API.md
+++ b/src/docs/API.md
@@ -16,7 +16,7 @@
 
 **TextInputModal** - Creates adversary cards with stats, weapons, features, and damage values.
 
-**DataManager** - Persistence layer. Methods: `addAdversary()`, `addEnvironment()`, `getAdversaries()`, `getEnvironments()`, `deleteAdversary()`, `deleteEnvironment()`.
+**DataManager** - Persistence layer. Methods: `changeSetting()`, `addAdversary()`, `addEnvironment()`, `getAdversaries()`, `getEnvironments()`, `deleteAdversary()`, `deleteEnvironment()`.
 
 ## Form Utilities
 
@@ -41,3 +41,5 @@
 **openEncounterCalculator** - Battle difficulty calculator.
 
 **onEditClick** - Routes edit operations for both card types.
+
+**onCollapseClick** - Routes card collapse operations for both card types.

--- a/src/features/adversaries/creator/CardBuilder.ts
+++ b/src/features/adversaries/creator/CardBuilder.ts
@@ -77,7 +77,10 @@ export const buildCardHTML = (
     <div class="df-card-inner df-pseudo-cut-corners inner">
 		<button class="df-adv-edit-button" data-edit-mode-only="true" data-tooltip="duplicate & edit" aria-label="duplicate & edit">📝</button>
         ${hpStressRepeat}
+		<div class="df-name-container">
+		<button class="df-adv-collapse-button"></button>
         <h2>${name}</h2>
+		</div>
         <div class="df-subtitle">Tier ${tier} ${type} ${sourceBadge}</div>
         <div class="df-desc">${desc}</div>
         <div class="df-motives">Motives & Tactics:
@@ -93,7 +96,7 @@ export const buildCardHTML = (
             <div class="df-experience-line">Experience: <span class="df-stat">${xp}</span></div>
         </div>
         <div class="df-section">FEATURES</div>
-        ${featuresHTML}
+		${featuresHTML}
     </div>
 </section>
 `.trim();

--- a/src/features/adversaries/index.ts
+++ b/src/features/adversaries/index.ts
@@ -1,4 +1,3 @@
-export * from './components/AdvList';
 export * from './components/AdvSearch';
 export * from './components/AdvCounter';
 export * from './creator/CardBuilder';

--- a/src/features/cardCollapse.ts
+++ b/src/features/cardCollapse.ts
@@ -1,0 +1,47 @@
+import { Notice, App } from "obsidian";
+import type DaggerForgePlugin from "../main";
+import { getActiveCanvas } from "@/utils";
+
+export const onCollapseClick = (
+    evt: Event,
+    cardType: string,
+) => {
+    evt.stopPropagation();
+
+    const button = evt.target as HTMLElement;
+    let cardElement: HTMLElement | null = null;
+    
+    if (cardType === "adv") {
+        cardElement = button.closest(".df-card-outer");
+    }
+
+    if (!cardElement) {
+        new Notice("Could not find card element!");
+        return;
+    }
+
+    const toggleElement = (element: HTMLElement | string): void => {
+        if (typeof element === 'string'){
+            new Notice(`Could not find ${element}!`);
+            return;
+        }
+        element.hidden = !element.hidden;
+        return;
+    }
+
+    let hiddenElementClasses: string[] = [];
+    //Temporary, meant to symbolize settings chosen.
+    hiddenElementClasses.push(".df-adv-edit-button",".df-subtitle",".df-desc",".df-motives", ".df-section", ".df-feature");
+    //
+    hiddenElementClasses.forEach(elementClass => {
+        if (elementClass === ".df-feature"){
+            Array.from(cardElement?.querySelectorAll<HTMLElement>(elementClass)).forEach(element => {
+                toggleElement(element ?? elementClass);
+            });
+        } else {
+            toggleElement(cardElement?.querySelector<HTMLElement>(elementClass) ?? elementClass);
+        }
+    });
+
+    button.style.rotate = (button.style.rotate === "-90deg" ? "0deg" : "-90deg");
+}

--- a/src/features/cardEditor.ts
+++ b/src/features/cardEditor.ts
@@ -1,6 +1,6 @@
 import { MarkdownView, Notice, App } from "obsidian";
 import type DaggerForgePlugin from "../main";
-import { EnvironmentEditorModal } from ".";
+import { EnvironmentEditorModal, onCollapseClick } from ".";
 import { extractCardData, TextInputModal } from "./adversaries/index";
 import type { EnvironmentData, EnvSavedFeatureState } from "../types/index";
 
@@ -311,7 +311,9 @@ export async function handleCardClick(evt: MouseEvent, app: App, plugin?: Dagger
 
 	let cardType: "env" | "adv" | null = null;
 	if (target.matches(".df-env-edit-button")) cardType = "env";
-	else if (target.closest(".df-adv-edit-button")) cardType = "adv";
+	else if (target.matches(".df-adv-edit-button")) cardType = "adv";
+	// With the way the clicks are currently handled, I am not aware of a better way to check than this.
+	else if (target.matches(".df-adv-collapse-button")) onCollapseClick(evt, "adv");
 
 	if (!cardType) return;
 

--- a/src/features/cardEditor.ts
+++ b/src/features/cardEditor.ts
@@ -300,20 +300,20 @@ export const onEditClick = (
 	}
 };
 
-export async function handleCardEditClick(evt: MouseEvent, app: App, plugin?: DaggerForgePlugin) {
+export async function handleCardClick(evt: MouseEvent, app: App, plugin?: DaggerForgePlugin) {
 	const target = evt.target as HTMLElement;
 	if (!target) return;
+	
+	if (!plugin) {
+		new Notice("Plugin instance not available for editing.");
+		return;
+	}
 
 	let cardType: "env" | "adv" | null = null;
 	if (target.matches(".df-env-edit-button")) cardType = "env";
 	else if (target.closest(".df-adv-edit-button")) cardType = "adv";
 
 	if (!cardType) return;
-
-	if (!plugin) {
-		new Notice("Plugin instance not available for editing.");
-		return;
-	}
 
 	// Check if we're on a canvas
 	const activeLeaf = app.workspace.activeLeaf;

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -3,3 +3,4 @@ export * from './adversaries/index';
 export * from './environments/index';
 export * from './extra';
 export * from './cardEditor';
+export * from './cardCollapse'

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 	environmentToHTML,
 	openDiceRoller,
 	openEncounterCalculator,
-	handleCardEditClick,
+	handleCardClick,
 } from "./features/index";
 
 import {
@@ -21,6 +21,7 @@ import {
 } from "./ui/index";
 
 import { DataManager } from "./data/index";
+import { DaggerForgeSettingTab } from "./settings";
 
 export default class DaggerForgePlugin extends Plugin {
 	updateCardData() {
@@ -34,7 +35,7 @@ export default class DaggerForgePlugin extends Plugin {
 		this.dataManager = new DataManager(this);
 		await this.dataManager.load();
 		this.addStatusBarItem().setText("DaggerForge Active");
-		this.registerDomEvent(document, "click", (evt) => handleCardEditClick(evt, this.app, this));
+		this.registerDomEvent(document, "click", (evt) => handleCardClick(evt, this.app, this));
 		this.registerView(
 			ADVERSARY_VIEW_TYPE,
 			(leaf) => new AdversaryView(leaf),
@@ -43,6 +44,8 @@ export default class DaggerForgePlugin extends Plugin {
 			ENVIRONMENT_VIEW_TYPE,
 			(leaf) => new EnvironmentView(leaf),
 		);
+
+		this.addSettingTab(new DaggerForgeSettingTab(this.app, this));
 
 		this.addRibbonIcon(
 			"scroll-text",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,31 @@
+import DaggerForgePlugin from '@/main';
+import { App, PluginSettingTab, Setting } from 'obsidian';
+
+export interface DaggerForgeSettings {
+    collapseButtonHidden: boolean;
+}
+
+export const DEFAULT: DaggerForgeSettings = {
+    collapseButtonHidden: true,
+}
+
+export function collapseButtonToggle(value: boolean) {
+    document.documentElement.style.setProperty('--df-collapse-button-display', (value ? 'none' : 'flex'));
+}
+
+export class DaggerForgeSettingTab extends PluginSettingTab {
+  plugin: DaggerForgePlugin;
+
+  constructor(app: App, plugin: DaggerForgePlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+    display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,15 @@ export class DaggerForgeSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
-    
+    new Setting(containerEl)
+      .setName('Hide collapse arrow')
+      .setDesc('On cards, the collapse arrow will be hidden unless the name is hovered over.')
+      .addToggle(toggle => toggle 
+        .setValue(this.plugin.dataManager.settings.collapseButtonHidden)
+        .onChange(async (value) => { 
+            await this.plugin.dataManager.changeSetting('collapseButtonHidden', value);
+            collapseButtonToggle(value);
+        })
+      );
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 :root {
+  --df-collapse-button-display: none;
   --df-corner: 10px;
   --df-font: "Myriad Pro";
   --df-color-primary: #000;
@@ -184,6 +185,26 @@
 
 .df-card-inner .df-stat {
 	font-weight: 400;
+}
+
+.df-name-container {
+	display: flex;
+	justify-content: left;
+}
+
+.df-name-container:hover .df-adv-collapse-button {
+	display: flex;
+}
+
+.df-adv-collapse-button {
+	display: var(--df-collapse-button-display);
+	width: 1px; /*Without these the button crops weird, but the size does not actually do anything. I do not know enough CS to understand whats happening.*/
+	height: 1px;
+	padding-bottom: 20px;
+	margin-right: 5px;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 13.1l-8-8 2.1-2.2 5.9 5.9 5.9-5.9 2.1 2.2z'/%3E%3C/svg%3E");
+	background-color: var(--df-color-bg-inner) !important;
+	box-shadow: none !important;
 }
 
 .df-stats .df-experience-line {


### PR DESCRIPTION
I meant to do this in piecemeal, but it ended up all going as one, so I might as well. 
I made the adversary cards collapsible by adding a simple button, and intend on adding this to environments as well. I also may add even more collapse buttons for features so you can really make it compact.

I also added settings because I could not decide if I wanted the button to be invisible or not.